### PR TITLE
Implement option to translate image from clipboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ mtl-cache.bin
 *.log
 
 test_images/
+
+# Build folders
+build/windows*/
+build/linux*/
+build/darwin*/

--- a/README.md
+++ b/README.md
@@ -84,13 +84,16 @@ Do one of the following:
 ### Command
 
 ```
-Usage: manga-translator.exe [OPTIONS] IMAGE_LOCATION
+Usage: manga-translator.exe [OPTIONS] [IMAGE_LOCATION]
+
+
+Arguments:
+  IMAGE_LOCATION   The path or URL of the image (not required if using -clip option).
 
 Options:
-  -url   Use an image from a URL instead of a local file.
+  -url             Use an image from a URL instead of a local file.
+  -clip            Use an image from your clipboard.
 ```
-
-> IMAGE_LOCATION must be a path or a URL.
 
 > Note: You can also open images with the `manga-translator` application itself
 (on Windows, you can easily do this by dragging the image on top of `manga-translator.exe`)

--- a/cmd/manga-translator/main.go
+++ b/cmd/manga-translator/main.go
@@ -35,21 +35,26 @@ func main() {
 
 	// Parse flags.
 	urlImagePtr := flag.Bool("url", false, "Use an image from a URL instead of a local file.")
+	clipImagePtr := flag.Bool("clip", false, "Use an image from the clipboard.") // overrides url
 	flag.Parse()
 	log.Infof("Use URL image: %v", *urlImagePtr)
+	log.Infof("Use clipboard image: %v", *clipImagePtr)
 
 	// Set up config, create new config if necessary.
 	var cfg config.File
 	config.Setup(applicationPath, &cfg)
 
 	// Open/download selected image and get its info.
-	if len(flag.Args()) == 0 {
+	if len(flag.Args()) == 0 && !*clipImagePtr {
 		log.Fatal("No path or URL given.")
 	}
-	imageFile := flag.Args()[0]
-	log.Infof("Selected Image: %v", imageFile)
+	var imageFile string
+	if !*clipImagePtr {
+		imageFile = flag.Args()[0]
+		log.Infof("Selected Image: %v", imageFile)
+	}
 
-	mainImage, imgHash := imageW.Open(imageFile, *urlImagePtr)
+	mainImage, imgHash := imageW.Open(imageFile, *urlImagePtr, *clipImagePtr)
 	hashInBytes := imgHash.Sum(nil)
 	imgHashStr := hex.EncodeToString(hashInBytes)
 	log.Debugf("hash: %v", imgHashStr)
@@ -67,7 +72,7 @@ func main() {
 			app.MinSize(unit.Dp(600), unit.Dp(300)),
 		)
 
-		if err := window.DrawFrame(w, mainImage, imageFile, imgHashStr, dims, *urlImagePtr, cfg); err != nil {
+		if err := window.DrawFrame(w, mainImage, imageFile, imgHashStr, dims, *urlImagePtr, *clipImagePtr, cfg); err != nil {
 			log.Fatal(err)
 		}
 		os.Exit(0)

--- a/go.mod
+++ b/go.mod
@@ -35,9 +35,11 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
+	golang.design/x/clipboard v0.5.3 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
 	golang.org/x/exp v0.0.0-20210722180016-6781d3edade3 // indirect
 	golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d // indirect
+	golang.org/x/mobile v0.0.0-20210716004757-34ab1303b554 // indirect
 	golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420 // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect

--- a/go.sum
+++ b/go.sum
@@ -464,6 +464,8 @@ go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
 go.uber.org/zap v1.16.0/go.mod h1:MA8QOfq0BHJwdXa996Y4dYkAqRKB8/1K1QMMZVaNZjQ=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
+golang.design/x/clipboard v0.5.3 h1:JUxlkxohMUtpFcwPu1JjsAlkndNq8UVVeOBDAGE/il8=
+golang.design/x/clipboard v0.5.3/go.mod h1:ep0pB+/4DGJK3ayLxweWJFHhHGGv3npJJHMXAjtLTUM=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -506,6 +508,8 @@ golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPI
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mobile v0.0.0-20201217150744-e6ae53a27f4f/go.mod h1:skQtrUTUwhdJvXM/2KKJzY8pDgNr9I/FOMqDVRPBUS4=
+golang.org/x/mobile v0.0.0-20210716004757-34ab1303b554 h1:3In5TnfvnuXTF/uflgpYxSCEGP2NdYT37KsPh3VjZYU=
+golang.org/x/mobile v0.0.0-20210716004757-34ab1303b554/go.mod h1:jFTmtFYCV0MFtXBU+J5V/+5AUeVS0ON/0WkE/KSrl6E=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=

--- a/pkg/window/window.go
+++ b/pkg/window/window.go
@@ -34,7 +34,7 @@ var (
 )
 
 // DrawFrame squares with labels, buttons control labels. "url" states if the given imgPath is a URL or not.
-func DrawFrame(w *app.Window, img *image.RGBA, imgPath string, imgHash string, imgDims imageW.Dimensions, url bool, cfg config.File) error {
+func DrawFrame(w *app.Window, img *image.RGBA, imgPath string, imgHash string, imgDims imageW.Dimensions, url, clip bool, cfg config.File) error {
 
 	// ops are the operations from the UI
 	var ops op.Ops
@@ -67,7 +67,7 @@ func DrawFrame(w *app.Window, img *image.RGBA, imgPath string, imgHash string, i
 
 		if blocks == nil {
 			// Scan image, get text annotation.
-			annotation, err := detect.GetAnnotation(imgPath, url)
+			annotation, err := detect.GetAnnotation(imgPath, url, clip)
 			if err != nil {
 				blocks = []detect.TextBlock{}
 				selectedO = err.Error()

--- a/scripts/darwin/README.txt
+++ b/scripts/darwin/README.txt
@@ -13,3 +13,7 @@ For images from a URL (2 options):
 For local images (2 options):
 1. run "translate-local-image.sh" and paste the image path.
 2. run "manga-translator <IMAGE PATH>" from the command line.
+
+For images in your clipboard (2 options):
+1. run "translate-clipboard-image.sh".
+2. run "manga-translator -clip" from the command line.

--- a/scripts/darwin/translate-clipboard-image.sh
+++ b/scripts/darwin/translate-clipboard-image.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./manga-translator -clip=true

--- a/scripts/linux/README.txt
+++ b/scripts/linux/README.txt
@@ -13,3 +13,7 @@ For images from a URL (2 options):
 For local images (2 options):
 1. run "translate-local-image.sh" and paste the image path.
 2. run "manga-translator <IMAGE PATH>" from the command line.
+
+For images in your clipboard (2 options):
+1. run "translate-clipboard-image.sh".
+2. run "manga-translator -clip" from the command line.

--- a/scripts/linux/translate-clipboard-image.sh
+++ b/scripts/linux/translate-clipboard-image.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./manga-translator -clip=true

--- a/scripts/windows/README.txt
+++ b/scripts/windows/README.txt
@@ -14,3 +14,10 @@ For local images (3 options):
 1. run "translate-local-image.bat" and paste the image path.
 2. drag and drop the image on top of manga-translator.exe (open with manga-translator.exe).
 3. run "manga-translator.exe <IMAGE PATH>" from the command line.
+
+For images in your clipboard (2 options):
+1. run "translate-clipboard-image.bat".
+2. run "manga-translator.exe -clip" from the command line.
+
+Note: the clipboard translation option is very useful when used
+in conjunction with the Windows snipping tool (Windows key + Shift + S)

--- a/scripts/windows/translate-clipboard-image.bat
+++ b/scripts/windows/translate-clipboard-image.bat
@@ -1,0 +1,1 @@
+start "" "./manga-translator.exe" -clip

--- a/scripts/windows/translate-local-image.bat
+++ b/scripts/windows/translate-local-image.bat
@@ -1,2 +1,2 @@
 set /p imgPath=Enter the image path:
-"./manga-translator.exe" %imgPath%
+start "" "./manga-translator.exe" %imgPath%

--- a/scripts/windows/translate-url-image.bat
+++ b/scripts/windows/translate-url-image.bat
@@ -1,2 +1,2 @@
 set /p inputURL=Enter the image URL:
-"./manga-translator.exe" -url %inputURL%
+start "" "./manga-translator.exe" -url %inputURL%


### PR DESCRIPTION
Add new option to translate an image from your clipboard. 

The built-in Windows snipping tool (there are also Linux and Mac equivalents) allows you to freely select a portion of your screen and copies it as an image to your clipboard. Using the new clipboard option in conjunction with the Windows snipping tool makes it much easier to do quick adjustments and translations without needing to save a new image every time.

Resolves #3