### PR TITLE
Fix panic when no text found

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cameronkinsella/manga-translator
 
-go 1.18
+go 1.23
 
 require (
 	cloud.google.com/go/translate v1.2.0

--- a/pkg/detect/detect.go
+++ b/pkg/detect/detect.go
@@ -61,7 +61,7 @@ func GetAnnotation(img *image.RGBA) (*pb.TextAnnotation, error) {
 
 	if annotation == nil {
 		log.Info("No text found")
-		return nil, nil
+		return nil, errors.New("no text found")
 	} else {
 		log.WithField("text", annotation.Text).Info("Detected Text")
 		return annotation, nil


### PR DESCRIPTION
Fixed a panic that occurs when no text is detected on a translated page.

Resolves #9 